### PR TITLE
Fix broken branch alias / fatal errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.x-dev"
+            "dev-main": "3.x-dev"
         }
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c34fd11377cb81e90b8f8a5cdb1e014",
+    "content-hash": "f63b321e481f233fad4f762c9911abbf",
     "packages": [
         {
             "name": "psr/container",
@@ -2848,5 +2848,5 @@
         "php": ">=8.0.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
The Composer branch alias needs to be updated to reflect the new 3.x major release.

This is causing errors in downstream projects, such as:

> Fatal error: Declaration of Robo\Task\BaseTask::setLogger(Psr\Log\LoggerInterface $logger) must be compatible with Psr\Log\LoggerAwareInterface::setLogger(Psr\Log\LoggerInterface $logger): void in /Users/dane.powell/sites/drupal-canary-project/vendor/consolidation/robo/src/Common/TaskIO.php on line 30

The problem is that the major versions of consolidation/log and psr/log must match because of a breaking change in the definition of `setLogger()`. But if a project (in this case consolidation/robo) requires consolidation/log:^2, it will actually get dev-main which is effectively psr/log 3.x, and you get a fatal error.

To reproduce:

1. `composer create-project acquia/drupal-canary-project:dev-drupal10`
2. `cd drupal-recommended-project`
3. `composer require acquia/blt`