### PR TITLE
Allow Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=8.0.0",
         "psr/log": "^3",
-        "symfony/console": "^5 || ^6 || ^7"
+        "symfony/console": "^5 || ^6 || ^7 || ^8"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5.20 || ^8 || ^9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "402b01c02c2dcba02ae6f3b980db8c71",
+    "content-hash": "413d06162e9af456035d51e6aa0d84f9",
     "packages": [
         {
             "name": "psr/container",
@@ -2576,12 +2576,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.0.0"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Widen symfony/* constraints to allow ^8.

No code changes needed — the APIs used by this package are unchanged in Symfony 8.

Ref: https://github.com/drush-ops/drush/issues/6536