### PR TITLE
Add Symfony major version matrix to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: ./tools/vendor/bin/roave-backward-compatibility-check --from=3.0.0
 
   tests:
-    name: Tests
+    name: Tests ${{ matrix.symfony && format('(Symfony {0})', matrix.symfony) || '' }}
 
     runs-on: ${{ matrix.os }}
 
@@ -93,6 +93,9 @@ jobs:
         
         codecov:
           - false
+
+        symfony:
+          - ""
 
         include:
           - os: ubuntu-latest
@@ -118,6 +121,26 @@ jobs:
             dependencies: highest
             codecov: true
             php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
+
+          - os: ubuntu-latest
+            php-version: "8.2"
+            dependencies: highest
+            symfony: "5"
+
+          - os: ubuntu-latest
+            php-version: "8.2"
+            dependencies: highest
+            symfony: "6"
+
+          - os: ubuntu-latest
+            php-version: "8.2"
+            dependencies: highest
+            symfony: "7"
+
+          - os: ubuntu-latest
+            php-version: "8.2"
+            dependencies: highest
+            symfony: "8"
 
     steps:
       - name: Checkout
@@ -166,6 +189,10 @@ jobs:
       - name: Install highest dependencies with composer
         if: matrix.dependencies == 'highest'
         run: composer update --no-ansi --no-interaction --no-progress
+
+      - name: Require Symfony ${{ matrix.symfony }}
+        if: matrix.symfony != ''
+        run: composer require --no-interaction --no-progress symfony/console:^${{ matrix.symfony }}
 
       - name: Run tests with phpunit
         run: composer unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,12 +123,12 @@ jobs:
             php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
 
           - os: ubuntu-latest
-            php-version: "8.2"
+            php-version: "8.0"
             dependencies: highest
             symfony: "5"
 
           - os: ubuntu-latest
-            php-version: "8.2"
+            php-version: "8.1"
             dependencies: highest
             symfony: "6"
 
@@ -138,7 +138,7 @@ jobs:
             symfony: "7"
 
           - os: ubuntu-latest
-            php-version: "8.2"
+            php-version: "8.5"
             dependencies: highest
             symfony: "8"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
 
       - name: Require Symfony ${{ matrix.symfony }}
         if: matrix.symfony != ''
-        run: composer require --no-interaction --no-progress symfony/console:^${{ matrix.symfony }}
+        run: composer require --no-interaction --no-progress --with-all-dependencies symfony/console:^${{ matrix.symfony }}
 
       - name: Run tests with phpunit
         run: composer unit


### PR DESCRIPTION
## Summary
- Adds CI matrix entries to test each supported Symfony major version (5, 6, 7, 8) independently
- Each matrix entry runs `composer require` to pin the Symfony console dependency to a specific major version before running tests
- Default test entries remain unchanged (run as-is without pinning)

## Test plan
- [ ] Verify each Symfony version matrix entry runs successfully
- [ ] Confirm default test entries are unaffected